### PR TITLE
Edit profile option + Check token fix

### DIFF
--- a/src/api/controllers/UserdataApi.ts
+++ b/src/api/controllers/UserdataApi.ts
@@ -1,6 +1,9 @@
 import { userdataUserApi } from '../userdata/UserdataUserApi';
 import { apply, checkToken, showErrorToast } from './auth/decorators';
+import { userdataCategoryApi } from '../userdata/UserdataCategoryApi';
 
 export class UserdataApi {
 	static getUser = apply(async (id: number) => await userdataUserApi.getById(id), [checkToken], [showErrorToast]);
+
+	static getCategories = apply(async (info: string) => await userdataCategoryApi.getAll());
 }

--- a/src/api/controllers/UserdataApi.ts
+++ b/src/api/controllers/UserdataApi.ts
@@ -1,6 +1,6 @@
 import { userdataUserApi } from '../userdata/UserdataUserApi';
-import { apply, showErrorToast } from './auth/decorators';
+import { apply, checkToken, showErrorToast } from './auth/decorators';
 
 export class UserdataApi {
-	static getUser = apply(async (id: number) => await userdataUserApi.getById(id), [showErrorToast]);
+	static getUser = apply(async (id: number) => await userdataUserApi.getById(id), [checkToken], [showErrorToast]);
 }

--- a/src/api/controllers/UserdataApi.ts
+++ b/src/api/controllers/UserdataApi.ts
@@ -1,9 +1,20 @@
 import { userdataUserApi } from '../userdata/UserdataUserApi';
 import { apply, checkToken, showErrorToast } from './auth/decorators';
 import { userdataCategoryApi } from '../userdata/UserdataCategoryApi';
+import { UserdataUpdateUser } from '../models';
 
 export class UserdataApi {
 	static getUser = apply(async (id: number) => await userdataUserApi.getById(id), [checkToken], [showErrorToast]);
 
-	static getCategories = apply(async (info: string) => await userdataCategoryApi.getAll());
+	static getCategories = apply(
+		async () => await userdataCategoryApi.getAllWithParams(),
+		[checkToken],
+		[showErrorToast],
+	);
+
+	static patchUserById = apply(
+		async (id: number, body: UserdataUpdateUser) => await userdataUserApi.patchById(id, body),
+		[checkToken],
+		[showErrorToast],
+	);
 }

--- a/src/api/controllers/UserdataApi.ts
+++ b/src/api/controllers/UserdataApi.ts
@@ -1,6 +1,6 @@
 import { userdataUserApi } from '../userdata/UserdataUserApi';
-import { apply, checkToken, showErrorToast } from './auth/decorators';
+import { apply, showErrorToast } from './auth/decorators';
 
 export class UserdataApi {
-	static getUser = apply(async (id: number) => await userdataUserApi.getById(id), [checkToken], [showErrorToast]);
+	static getUser = apply(async (id: number) => await userdataUserApi.getById(id), [showErrorToast]);
 }

--- a/src/api/controllers/auth/decorators.ts
+++ b/src/api/controllers/auth/decorators.ts
@@ -52,8 +52,6 @@ export function checkToken<F extends Func<any, any>>(method: F): Func<Promise<Re
 	return async (...args: any[]) => {
 		try {
 			await userSessionApi.getMe();
-			const response = await method(...args);
-			return response;
 		} catch (error) {
 			if (axios.isAxiosError(error) && error.response?.status === 403) {
 				const { deleteToken } = useProfileStore();
@@ -63,6 +61,8 @@ export function checkToken<F extends Func<any, any>>(method: F): Func<Promise<Re
 				toastStore.push({ title: 'Сессия истекла' });
 			}
 		}
+		const response = await method(...args);
+		return response;
 	};
 }
 

--- a/src/api/models/index.ts
+++ b/src/api/models/index.ts
@@ -118,9 +118,27 @@ export interface UserdataParam extends Entity {
 export interface UserdataRawItem {
 	category: string;
 	param: string;
-	value: string;
+	value: UserdataExtendedValue | string;
 }
 
 export interface UserdataRaw {
 	items: UserdataRawItem[];
+}
+
+export interface UserdataExtendedValue {
+	name: string;
+	is_required?: boolean;
+	changeable?: boolean;
+	type?: UserdataParamResponseType;
+}
+
+export interface UserdataUpdateUserItem {
+	category: string;
+	param: string;
+	value: string | null;
+}
+
+export interface UserdataUpdateUser {
+	items: UserdataUpdateUserItem[];
+	source: string;
 }

--- a/src/api/models/index.ts
+++ b/src/api/models/index.ts
@@ -98,6 +98,7 @@ export interface UserdataCategory extends Entity {
 	name: string;
 	read_scope?: string;
 	update_scope?: string;
+	params?: UserdataParam[];
 }
 
 export enum UserdataParamResponseType {

--- a/src/api/userdata/UserdataCategoryApi.ts
+++ b/src/api/userdata/UserdataCategoryApi.ts
@@ -5,6 +5,10 @@ class UserdataCategoryApi extends EntityBaseApi<UserdataCategory> {
 	constructor() {
 		super('/userdata/category');
 	}
+
+	public async getAllWithParams() {
+		return this.get<UserdataCategory[]>('?query=param');
+	}
 }
 
 export const userdataCategoryApi = new UserdataCategoryApi();

--- a/src/api/userdata/UserdataUserApi.ts
+++ b/src/api/userdata/UserdataUserApi.ts
@@ -1,4 +1,4 @@
-import { UserdataRaw } from '../models';
+import { UserdataRaw, UserdataUpdateUser } from '../models';
 import { UserdataBaseApi } from './UserdataBaseApi';
 
 type Json = Record<string, Record<string, string>>;
@@ -12,8 +12,8 @@ class UserdataUserApi extends UserdataBaseApi {
 		return this.get<UserdataRaw>(`/${id}`);
 	}
 
-	public async patchById(id: number, body: Json) {
-		return this.post<Json, Json>(`/${id}`, body);
+	public async patchById(id: number, body: UserdataUpdateUser) {
+		return this.post<Json, UserdataUpdateUser>(`/${id}`, body);
 	}
 }
 

--- a/src/models/index.ts
+++ b/src/models/index.ts
@@ -1,3 +1,5 @@
+import { UserdataExtendedValue } from '@/api/models';
+
 export { LocalStorage, LocalStorageItem } from './LocalStorage';
 export { scopename } from './ScopeName';
 
@@ -13,13 +15,18 @@ export interface Toast {
 	description?: string;
 }
 
-export type UserdataTreeSheet = Map<string, string>;
+export type UserdataTreeSheet = Map<string, UserdataExtendedValue>;
 
 export type UserdataTree = Map<string, UserdataTreeSheet>;
 
 export interface UserdataArrayDataItem {
 	param: string;
-	value: string;
+	value: UserdataExtendedValue;
+}
+
+export interface UserdataArrayCategoryItem {
+	category: string;
+	param: string;
 }
 
 export interface UserdataArrayItem {
@@ -33,10 +40,12 @@ export enum UserdataCategoryName {
 	PersonalInfo = 'Личная информация',
 	Study = 'Учёба',
 	Contacts = 'Контакты',
+	Career = 'Карьера',
 }
 
-export enum UserdataParamName {
+export enum UserdataParams {
 	FullName = 'Полное имя',
+	Photo = 'Фото',
 }
 
-export type UserdataConfig = Readonly<Record<UserdataCategoryName, Readonly<UserdataParamName[]>>>;
+export type UserdataConfig = Readonly<Record<UserdataCategoryName, Readonly<UserdataParams[]>>>;

--- a/src/models/index.ts
+++ b/src/models/index.ts
@@ -36,9 +36,7 @@ export enum UserdataCategoryName {
 }
 
 export enum UserdataParamName {
-	Surname = 'Фамилия',
-	Name = 'Имя',
-	Patronymic = 'Отчество',
+	FullName = 'Полное имя',
 }
 
 export type UserdataConfig = Readonly<Record<UserdataCategoryName, Readonly<UserdataParamName[]>>>;

--- a/src/router/profile.ts
+++ b/src/router/profile.ts
@@ -13,4 +13,12 @@ export const profileRoutes: RouteRecordRaw[] = [
 		path: ':id(\\d+)',
 		component: () => import('@/views/user/UserView.vue'),
 	},
+	{
+		path: 'edit',
+		component: () => import('@/views/profile/ProfileEditView.vue'),
+	},
+	{
+		path: 'edit-auth',
+		component: () => import('@/views/profile/ProfileEditAuthView.vue'),
+	},
 ];

--- a/src/utils/UserdataConverter.test.ts
+++ b/src/utils/UserdataConverter.test.ts
@@ -1,4 +1,4 @@
-import { UserdataRaw } from '@/api/models';
+import { UserdataParamResponseType, UserdataRaw } from '@/api/models';
 import { describe, it, expect } from 'vitest';
 import { UserdataConverter } from './UserdataConverter';
 import { UserdataArrayItem, UserdataTree, UserdataTreeSheet } from '@/models';
@@ -19,8 +19,24 @@ const flatResposne: UserdataRaw = {
 };
 
 const treeSheet: UserdataTreeSheet = new Map([
-	['street', 'Моховая'],
-	['city', 'Москва'],
+	[
+		'street',
+		{
+			name: 'Моховая',
+			is_required: true,
+			changeable: false,
+			type: UserdataParamResponseType.All,
+		},
+	],
+	[
+		'city',
+		{
+			name: 'Москва',
+			is_required: false,
+			changeable: true,
+			type: UserdataParamResponseType.All,
+		},
+	],
 ]);
 
 const expectedObject: UserdataTree = new Map([['Address', treeSheet]]);
@@ -30,11 +46,21 @@ const arrayItem: UserdataArrayItem = {
 	data: [
 		{
 			param: 'street',
-			value: 'Моховая',
+			value: {
+				name: 'Моховая',
+				is_required: true,
+				changeable: false,
+				type: UserdataParamResponseType.All,
+			},
 		},
 		{
 			param: 'city',
-			value: 'Москва',
+			value: {
+				name: 'Москва',
+				is_required: false,
+				changeable: true,
+				type: UserdataParamResponseType.All,
+			},
 		},
 	],
 };

--- a/src/utils/UserdataConverter.test.ts
+++ b/src/utils/UserdataConverter.test.ts
@@ -23,8 +23,8 @@ const treeSheet: UserdataTreeSheet = new Map([
 		'street',
 		{
 			name: 'Моховая',
-			is_required: true,
-			changeable: false,
+			is_required: false,
+			changeable: true,
 			type: UserdataParamResponseType.All,
 		},
 	],
@@ -48,8 +48,8 @@ const arrayItem: UserdataArrayItem = {
 			param: 'street',
 			value: {
 				name: 'Моховая',
-				is_required: true,
-				changeable: false,
+				is_required: false,
+				changeable: true,
 				type: UserdataParamResponseType.All,
 			},
 		},

--- a/src/utils/UserdataConverter.ts
+++ b/src/utils/UserdataConverter.ts
@@ -28,19 +28,16 @@ export class UserdataConverter {
 			if (!acc.has(item.category)) {
 				acc.set(item.category, new Map());
 			}
-			const extendedValue: UserdataExtendedValue = {
-				name: '',
-				is_required: false,
-				changeable: true,
-				type: UserdataParamResponseType.All,
-			};
+			let extendedValue: UserdataExtendedValue | undefined = undefined;
 			if (typeof item.value === 'string') {
-				extendedValue.name = item.value;
+				extendedValue = {
+					name: item.value,
+					is_required: false,
+					changeable: true,
+					type: UserdataParamResponseType.All,
+				};
 			} else {
-				extendedValue.name = item.value.name;
-				extendedValue.is_required = item.value.is_required;
-				extendedValue.changeable = item.value.changeable;
-				extendedValue.type = item.value.type;
+				extendedValue = item.value;
 			}
 			acc.get(item.category)!.set(item.param, extendedValue);
 			return acc;
@@ -204,7 +201,6 @@ export class UserdataConverter {
 					value: item.value,
 				} as UserdataUpdateUserItem;
 				updateUserdata.items.push(updateItem);
-				console.log('MEM');
 			}
 		}
 		return updateUserdata;

--- a/src/utils/UserdataConverter.ts
+++ b/src/utils/UserdataConverter.ts
@@ -11,11 +11,7 @@ import {
 
 const categoryOrder = [UserdataCategoryName.PersonalInfo, UserdataCategoryName.Study, UserdataCategoryName.Contacts];
 const userdataConfig: Partial<UserdataConfig> = {
-	[UserdataCategoryName.PersonalInfo]: [
-		UserdataParamName.Surname,
-		UserdataParamName.Name,
-		UserdataParamName.Patronymic,
-	] as const,
+	[UserdataCategoryName.PersonalInfo]: [UserdataParamName.FullName] as const,
 };
 
 export class UserdataConverter {
@@ -53,7 +49,7 @@ export class UserdataConverter {
 
 	public static treeToArray(tree: UserdataTree): UserdataArray {
 		const res: UserdataArray = [];
-		const name = [UserdataParamName.Name, UserdataParamName.Surname, UserdataParamName.Patronymic];
+		const name = UserdataParamName.FullName;
 		for (const [category, sheet] of tree.entries()) {
 			for (const param of sheet.keys()) {
 				if (UserdataConverter.hasFullName && name.includes(param as UserdataParamName)) {
@@ -82,14 +78,12 @@ export class UserdataConverter {
 	public static getFullName(flat: UserdataRaw) {
 		const tree = UserdataConverter.flatToTree(flat);
 		const info = tree.get(UserdataCategoryName.PersonalInfo);
-		const name = info?.get(UserdataParamName.Name) ?? '';
-		const surname = info?.get(UserdataParamName.Surname) ?? '';
-		const patronymic = info?.get(UserdataParamName.Patronymic) ?? '';
+		const full_name = info?.get(UserdataParamName.FullName) ?? '';
 
-		if (!name && !surname && !patronymic) {
+		if (!full_name) {
 			return '[object Object]';
 		}
 		UserdataConverter.hasFullName = true;
-		return `${surname} ${name} ${patronymic}`.trim();
+		return `${full_name}`.trim();
 	}
 }

--- a/src/utils/UserdataConverter.ts
+++ b/src/utils/UserdataConverter.ts
@@ -83,7 +83,36 @@ export class UserdataConverter {
 		if (!full_name) {
 			return '[object Object]';
 		}
-		UserdataConverter.hasFullName = true;
-		return `${full_name}`.trim();
+	}
+
+	public static categoryToFlat(categories: UserdataCategory[]) {
+		const result: UserdataRaw = { items: [] };
+		categories.forEach(category => {
+			category.params?.forEach(param => {
+				result.items.push({ category: category.name, param: param, value: '' } as UserdataRawItem);
+			});
+		});
+		return result;
+	}
+
+	public static uniteWithUserCategories(categories: UserdataRaw, userCategories: UserdataRaw): UserdataArray {
+		const result_userdata: UserdataArray = [];
+		const categoriesTree = UserdataConverter.flatToTree(categories);
+		const userCategoriesTree = UserdataConverter.flatToTree(userCategories);
+		categoriesTree.forEach((item, category) => {
+			const category_info: UserdataArrayDataItem[] = [];
+			item.forEach((value, param) => {
+				if (userCategoriesTree.get(category) && userCategoriesTree.get(category)?.get(param)) {
+					const userValue = userCategoriesTree.get(category)?.get(param);
+					if (userValue) {
+						category_info.push({ param: param, value: userValue });
+					}
+				} else {
+					category_info.push({ param: param, value: value });
+				}
+			});
+			result_userdata.push({ name: category, data: category_info });
+		});
+		return result_userdata;
 	}
 }

--- a/src/views/profile/ProfileEditAuthView.vue
+++ b/src/views/profile/ProfileEditAuthView.vue
@@ -1,0 +1,56 @@
+<script setup lang="ts">
+import { IrdomLayout, IrdomAuthButton, TelegramButton } from '@/components';
+import { useProfileStore } from '@/store';
+import { onMounted, computed } from 'vue';
+import { AuthMethod } from '@/api/auth';
+import { authButtons } from '@/constants';
+
+const profileStore = useProfileStore();
+
+onMounted(async () => {
+	if (history.state.token) {
+		profileStore.updateToken(history.state.token);
+		delete history.state.token;
+	}
+});
+
+const canLinked = computed(() =>
+	authButtons.filter(({ method }) => !profileStore.authMethods?.includes(method) && method !== AuthMethod.Telegram),
+);
+const canUnlinked = computed(() => authButtons.filter(({ method }) => profileStore.authMethods?.includes(method)));
+</script>
+
+<template>
+	<IrdomLayout title="Методы авторизации" backable back="/profile">
+		<section v-if="profileStore.authMethods?.length !== 8" class="section">
+			<h2>Привязать аккаунт</h2>
+			<div class="buttons">
+				<IrdomAuthButton v-for="button of canLinked" :key="button.method" :button="button" />
+				<TelegramButton v-if="!profileStore.authMethods?.includes(AuthMethod.Telegram)" />
+			</div>
+		</section>
+
+		<section v-if="profileStore.authMethods && profileStore.authMethods.length > 1" class="section">
+			<h2>Отвязать аккаунт</h2>
+			<div class="buttons">
+				<IrdomAuthButton v-for="button of canUnlinked" :key="button.method" :button="button" unlink />
+			</div>
+		</section>
+	</IrdomLayout>
+</template>
+
+<style scoped>
+.buttons {
+	display: flex;
+	flex-wrap: wrap;
+	gap: 16px;
+}
+
+.section {
+	margin-bottom: 40px;
+
+	& h2 {
+		margin-bottom: 20px;
+	}
+}
+</style>

--- a/src/views/profile/ProfileEditView.vue
+++ b/src/views/profile/ProfileEditView.vue
@@ -11,8 +11,6 @@ import { UserdataArray, UserdataCategoryName, UserdataParams } from '@/models';
 import router from '@/router';
 import { UserdataExtendedValue } from '@/api/models';
 
-// import router from '@/router';
-
 const profileStore = useProfileStore();
 const fullName_item = ref<UserdataExtendedValue | null>();
 const photoURL_item = ref<UserdataExtendedValue | null>();
@@ -34,7 +32,6 @@ onMounted(async () => {
 	]);
 	const { data: user } = await UserdataApi.getUser(me.id);
 	const { data } = await UserdataApi.getCategories();
-	console.log(data);
 	fullName_item.value = UserdataConverter.getItem(user, {
 		category: UserdataCategoryName.PersonalInfo,
 		param: UserdataParams.FullName,
@@ -63,7 +60,7 @@ async function saveEdit() {
 			value: fullName.value,
 		},
 	]);
-	UserdataApi.patchUserById(me.id, updateBody);
+	await UserdataApi.patchUserById(me.id, updateBody);
 	router.push('/profile');
 }
 </script>
@@ -153,12 +150,6 @@ async function saveEdit() {
 	object-fit: cover;
 	position: relative;
 	z-index: 2;
-}
-
-.buttons {
-	display: flex;
-	flex-wrap: wrap;
-	gap: 16px;
 }
 
 .section {

--- a/src/views/profile/ProfileEditView.vue
+++ b/src/views/profile/ProfileEditView.vue
@@ -71,7 +71,7 @@ async function saveEdit() {
 <template>
 	<IrdomLayout title="Профиль" class-name="profile-toolbar">
 		<img :src="photoURL" alt="Аватар" width="400 " height="400" class="avatar" />
-		<input
+		<textarea
 			v-model="fullName"
 			outline="none"
 			:readonly="!fullName_item?.changeable"

--- a/src/views/profile/ProfileView.vue
+++ b/src/views/profile/ProfileView.vue
@@ -8,15 +8,19 @@ import { MySessionInfo } from '@/api/auth';
 import { useRouter } from 'vue-router';
 import { UserdataApi } from '@/api/controllers/UserdataApi';
 import { UserdataConverter } from '@/utils';
-import { UserdataArray } from '@/models';
+import { UserdataArray, UserdataCategoryName, UserdataParams } from '@/models';
 import AchievementsSlider from './achievement/AchievementsSlider.vue';
+import { UserdataExtendedValue } from '@/api/models';
 
 const profileStore = useProfileStore();
 const router = useRouter();
 
 const userdata = ref<UserdataArray>([]);
 const userdataLoading = ref(false);
+const fullName_item = ref<UserdataExtendedValue | null>();
+const photoURL_item = ref<UserdataExtendedValue | null>();
 const fullName = ref('');
+const photoURL = ref('');
 
 const toolbarMenu: ToolbarMenuItem[] = [
 	{
@@ -56,7 +60,16 @@ onMounted(async () => {
 	]);
 
 	const { data } = await UserdataApi.getUser(me.id);
-	fullName.value = UserdataConverter.getFullName(data);
+	fullName_item.value = UserdataConverter.getItem(data, {
+		category: UserdataCategoryName.PersonalInfo,
+		param: UserdataParams.FullName,
+	});
+	photoURL_item.value = UserdataConverter.getItem(data, {
+		category: UserdataCategoryName.PersonalInfo,
+		param: UserdataParams.Photo,
+	});
+	fullName.value = fullName_item.value?.name ?? '[object Object]';
+	photoURL.value = photoURL_item.value?.name ?? Placeholder;
 	userdata.value = UserdataConverter.flatToArray(data);
 
 	userdataLoading.value = false;
@@ -65,8 +78,7 @@ onMounted(async () => {
 
 <template>
 	<IrdomLayout :toolbar-menu="toolbarMenu" title="Профиль" class-name="profile-toolbar">
-		<img :src="Placeholder" alt="Аватар" width="400 " height="400" class="avatar" />
-
+		<img :src="photoURL" alt="Аватар" width="400 " height="400" class="avatar" />
 		<span class="user-name">
 			{{ fullName }}
 		</span>
@@ -87,7 +99,7 @@ onMounted(async () => {
 							{{ param }}
 						</div>
 						<div class="userdata-value">
-							{{ value }}
+							{{ value.name }}
 						</div>
 					</div>
 				</div>
@@ -163,13 +175,14 @@ onMounted(async () => {
 
 .user-name {
 	margin-bottom: 32px;
+	text-align: center;
 	display: inline-block;
 	align-self: center;
 	color: #000;
 	font-kerning: none;
 	font-size: 32px;
 	font-weight: 700;
-	line-height: 20px;
+	line-height: 35px;
 	letter-spacing: 0.1px;
 }
 


### PR DESCRIPTION
## Изменения
1. Изменена проверка действительности токена пользователя.
2. Добавлен экран редактирования личного кабинета пользователя.

## Реализации

#### Проверка токена
1. Теперь при отработке декоратора CheckToken, чтобы проверить действительность токена, проверяется только работоспособность ручки `# GET /me` в [`auth-api`](github.com/profcomff/auth-api) и не проверяется декорируемый метод.
2. Реализованы методы получения информации из [`userdata-api`](github.com/profcomff/userdata-api), а также ее обновление.
3. Реализованы конвертеры данных, позволяющие сводить полученную информацию о пользователе к единому виду.

## Детали
### Проверка токена
1. Фикс проверки действительности токена необходим, так как декорируемый метод может вернуть ошибку HTTP-403 не из-за недействительности токена. 

### Редактирование личного кабинета

#### Получение данных и дальнейшее их отображение
1. Суть данной реализации состоит в том, что в начале мы получаем всевозможные и имеющиеся категории и параметры из [`userdata-api`](github.com/profcomff/userdata-api) благодаря несложным реализованным ручкам в `UserdataApi`. Ниже оговорок про них не будет.
2. Далее благодаря написанному методу `categoryToFlat` классе `UserdataConverter` мы конвертируем полученную информацию о всех категориях и параметрах в вид `UserdataRaw`. 
3. Такой же вид имеет информация, которая получается конкретно о **_пользователе_**, поэтому далее, благодаря уже реализованным методам конвертера, **_полная информация_** о категориях конвертируется в `UserdataArray`.
4. Методы для чтения и вывода `UserdataArray` уже были реализованы до, однако было желание выводить не только пустые строки с категориями и параметрами, а еще и заполнять те, которые у пользователя **_уже заполнены_**.
5. Для этого в `UserdataConverter` был добавлен метод `uniteWithUserCategories`, который принимает на себя два массива данных: тот, который имеет категории и параметры, **_заполненные пользователем_**, а также тот, который просто содержит в себе **_всевозможные данные_**.
6. Далее в данном методе они объединяются в одну единую модель типа `UserdataArray`, которую мы уже умеем выводить, как, собственно и написано выше.

#### Реализация изменяемых и обязательных полей
1. Так как в [`userdata-api`](github.com/profcomff/userdata-api) были реализованы такие поля как `is_required`, `changable`, `type` необходимо было придумать способ считывать данные поля при выводе.
3. Было решено отныне не просто получать **_значение_**, а расширить его благодаря модели данных `UserdataExtendedValue`, которое **_включало в себя все необходимые параметры_**.
4. Можно заметить, что на бэке вышеописанные поля принадлежат конкретно **_параметру, а не значению_**. Так почему же нужно было добавлять их именно к значению? Ответ прост, чтобы не переписывать полностью старую реализацию. 
5. В старой реализации в какой-то момент времени все данные приводятся в вид словарей, где **_ключами являются категории или параметры_**. Если сделать модель по типу `UserdataExtendedParam`, возникнут проблемы с тем, что **_подобный объект не сможет быть ключом к словарю_**, поэтому проще было сделать именно расширенное значение `ExtendedValue`.

#### Получение имени и фотографии
1. Раньше для получения имени имелась отдельная функция `getFullName`, которая была упразднена мной ввиду загромождения кода после добавления похожей функции `getPhotoURL`, которую вы уже не увидите в данной реализации. Был реализован более «‎абстрактный»‎ метод`getItem`, возвращающий `UserdataExtendedValue`.
2. Проблема получения имени и фотографии состояла в том, что это **_два отдельных параметра, которые мы должны получать и при желании редактировать._** Однако их нужно было вывести в **_отдельные блоки_** на исходной странице.
3. Поэтому было добавлено новое поле в класс `UserdataConverter` под названием `alreadyGetParams`. 
4. В данное поле добавляются все структуры из [`userdata-api`](github.com/profcomff/userdata-api), которые уже были получены в методе `getItem`.
6. Далее в методах, конвертирующих структуры из базы данных в `UserdataConverter`, **_данное поле проверяется_** и, в случае чего, параметры, указанные там, **_не добавляются в исходную структуру_**, подающуюся на результат.

#### Обновление информации о пользователе
1. Для считывания информации использовались теги: `<v-text-field>` и `<textarea>`.
2. После считывания информации было необходимо отправить запрос в [`userdata-api`](github.com/profcomff/userdata-api) для ее дальнейшего обновления.
3. Для этого в `UserdataConverter` реализован метод `arrayToUpdate`, принимающий в себя параметры на обновление, а также массив из параметров по типу `fullName` и `photoURL`, которые мы хотим **_получать и обновлять отдельно._**
4. Затем данные конвертируются в необходимый для отправки вид и прокидываются в ручку `PATCH` в [`userdata-api`](github.com/profcomff/userdata-api), используя source-отправки `user`.

## Check-List
- [x] Вы проверили свой код перед отправкой запроса?
- [x] Вы написали тесты к реализованным функциям?
- [x] Вы не забыли применить форматирование `black` и `isort` для _Back-End_ или `Prettier` для _Front-End_?

