### PR TITLE
фикс отсутствия ошибки при регистрации с невалидной почтой

### DIFF
--- a/src/api/controllers/auth/decorators.ts
+++ b/src/api/controllers/auth/decorators.ts
@@ -36,14 +36,13 @@ export function scoped<F extends Func>(
 
 export function showErrorToast<F extends Func>(
 	method: F
-): Func<Promise<{ error: any; response: ReturnType<F> | null }>, Parameters<F>> {
+): Func<Promise<ReturnType<F>>, Parameters<F>> {
 	return async (...args: any[]) => {
 		const toastStore = useToastStore();
 		try {
-			const response = await method(...args);
-			if ('error' in response) {
-				const errormessage = response.error?.detail?.[0].msg;
-				throw new Error(errormessage);
+			const { error, response } = await method(...args);
+			if (error) {
+				throw error;
 			} else {
 				return response;
 			}
@@ -61,7 +60,7 @@ export function showErrorToast<F extends Func>(
 					type: ToastType.Error,
 				});
 			}
-			return { error: err, response: null };
+			return undefined;
 		}
 	};
 }

--- a/src/api/controllers/auth/decorators.ts
+++ b/src/api/controllers/auth/decorators.ts
@@ -1,5 +1,4 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
-
 import { apiClient } from '../../client';
 import { ToastType } from '@/models';
 import router from '@/router';

--- a/src/api/controllers/auth/decorators.ts
+++ b/src/api/controllers/auth/decorators.ts
@@ -1,10 +1,12 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
-import { ApiError } from '@/api';
+//import { ApiError } from '@/api';
 import { apiClient } from '../../client';
 import { ToastType } from '@/models';
 import router from '@/router';
 import { useProfileStore } from '@/store/profile';
 import { useToastStore } from '@/store/toast';
+//import { error } from 'console';
+//import { toRaw } from 'vue';
 
 type Func<R = any, FuncArgs extends any[] = any[]> = (...args: FuncArgs) => R;
 type Decorator<F extends Func = Func, DecoratorArgs extends any[] = any[]> = Func<
@@ -37,17 +39,22 @@ export function scoped<F extends Func>(
 
 export function showErrorToast<F extends Func>(
 	method: F
-): Func<Promise<ReturnType<F>>, Parameters<F>> {
+): Func<Promise<{ error: any; response: ReturnType<F> | null }>, Parameters<F>> {
 	return async (...args: any[]) => {
 		const toastStore = useToastStore();
 		try {
 			const response = await method(...args);
-			return response;
-		} catch (err) {
-			const error = err as ApiError;
+			if ('error' in response) {
+				const errormessage = response.error?.detail?.[0].msg;
+				throw new Error(errormessage);
+			} else {
+				return response;
+			}
+		} catch (err: any) {
+			const error = err?.detail?.[0] ?? err;
 			if (error) {
 				toastStore.push({
-					title: error.ru ?? error.message,
+					title: error.ru ?? error.msg ?? error,
 					type: ToastType.Error,
 				});
 			} else {
@@ -57,6 +64,7 @@ export function showErrorToast<F extends Func>(
 					type: ToastType.Error,
 				});
 			}
+			return { error: err, response: null };
 		}
 	};
 }

--- a/src/api/controllers/auth/decorators.ts
+++ b/src/api/controllers/auth/decorators.ts
@@ -1,12 +1,10 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
-//import { ApiError } from '@/api';
+
 import { apiClient } from '../../client';
 import { ToastType } from '@/models';
 import router from '@/router';
 import { useProfileStore } from '@/store/profile';
 import { useToastStore } from '@/store/toast';
-//import { error } from 'console';
-//import { toRaw } from 'vue';
 
 type Func<R = any, FuncArgs extends any[] = any[]> = (...args: FuncArgs) => R;
 type Decorator<F extends Func = Func, DecoratorArgs extends any[] = any[]> = Func<


### PR DESCRIPTION
Действовал по шагам: 
Деструктурировать ответ method как {error, response}
Если есть error, то пробросить error
Обозначить переменную error в блоке catch на выражение: err?.detail?.[0]?? err;
В toastStore.push в поле title добавить ?? error.msg ?? error
В итоге должен показываться тост с Value error, 

Пришлось добавить err: any в catch, так как было неизвестно, есть ли detail у него
выброс ошибки возможно реализован коряво

## Check-List
<!-- После сохранения у следующих полей появятся галочки, которые нужно проставить мышкой -->
- [V] Вы проверили свой код перед отправкой запроса?
- [?] Вы написали тесты к реализованным функциям?
- [?] Вы не забыли применить форматирование `black` и `isort` для _Back-End_ или `Prettier` для _Front-End_?
