### PR TITLE
BUGFIX. Изменения в auth/decorators.ts. Для корректной работы AuthApi.getMe()

### DIFF
--- a/src/api/controllers/auth/decorators.ts
+++ b/src/api/controllers/auth/decorators.ts
@@ -36,30 +36,26 @@ export function scoped<F extends Func>(
 
 export function showErrorToast<F extends Func>(
 	method: F
-): Func<Promise<ReturnType<F>>, Parameters<F>> {
+): Func<Promise<Awaited<ReturnType<F>> | undefined>, Parameters<F>> {
 	return async (...args: any[]) => {
 		const toastStore = useToastStore();
+
 		try {
-			const { error, response } = await method(...args);
-			if (error) {
-				throw error;
-			} else {
-				return response;
+			const result = await method(...args);
+
+			if (result?.error) {
+				throw result.error;
 			}
+
+			return result;
 		} catch (err: any) {
 			const error = err?.detail?.[0] ?? err;
-			if (error) {
-				toastStore.push({
-					title: error.ru ?? error.msg ?? error,
-					type: ToastType.Error,
-				});
-			} else {
-				toastStore.push({
-					title: 'Неизвестная ошибка',
-					description: '',
-					type: ToastType.Error,
-				});
-			}
+
+			toastStore.push({
+				title: error?.ru ?? error?.msg ?? error?.message ?? String(error),
+				type: ToastType.Error,
+			});
+
 			return undefined;
 		}
 	};

--- a/src/api/controllers/auth/decorators.ts
+++ b/src/api/controllers/auth/decorators.ts
@@ -51,10 +51,18 @@ export function showErrorToast<F extends Func>(
 		} catch (err: any) {
 			const error = err?.detail?.[0] ?? err;
 
-			toastStore.push({
-				title: error?.ru ?? error?.msg ?? error?.message ?? String(error),
-				type: ToastType.Error,
-			});
+			if (error) {
+				toastStore.push({
+					title: error?.ru ?? error?.msg ?? error?.message ?? String(error),
+					type: ToastType.Error,
+				});
+			} else {
+				toastStore.push({
+					title: 'Неизвестная ошибка',
+					description: '',
+					type: ToastType.Error,
+				});
+			}
 
 			return undefined;
 		}


### PR DESCRIPTION
## Изменения
Для корректной работы AuthApi.getMe() (и, соответственно страницы ProfileView) нужен ответ в формате { data, error, response } вместо {response}. Я меняю функцию showErrorToast.

## Детали реализации
Меняю showErrorToast так, чтобы она возвращала { data, error, response } вместо {response

## Check-List
<!-- После сохранения у следующих полей появятся галочки, которые нужно проставить мышкой -->
- [ ] Вы проверили свой код перед отправкой запроса?
- [ ] Вы написали тесты к реализованным функциям?
- [ ] Вы не забыли применить форматирование `black` и `isort` для _Back-End_ или `Prettier` для _Front-End_?
